### PR TITLE
Proposal: Use error handling instead of failing silently

### DIFF
--- a/CacherDemo/ViewController.swift
+++ b/CacherDemo/ViewController.swift
@@ -13,12 +13,12 @@ class ViewController: UIViewController {
 	@IBOutlet weak var textField: UITextField!
 	
 	// Create a cacher and use the temporary directory
-	let cacher: Cacher = try! Cacher(destination: .temporary)
+	let cacher: Cacher = Cacher(destination: .temporary)!
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		// Do any additional setup after loading the view, typically from a nib.
-		if let cachedText: CachableText = try? cacher.load(fileName: "text") {
+		if let cachedText: CachableText = cacher.load(fileName: "text") {
 			// Replace the current text with the cached one
 			textField.text = cachedText.value
 		}

--- a/CacherDemo/ViewController.swift
+++ b/CacherDemo/ViewController.swift
@@ -13,12 +13,12 @@ class ViewController: UIViewController {
 	@IBOutlet weak var textField: UITextField!
 	
 	// Create a cacher and use the temporary directory
-	let cacher: Cacher = Cacher(destination: .temporary)
+	let cacher: Cacher = try! Cacher(destination: .temporary)
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		// Do any additional setup after loading the view, typically from a nib.
-		if let cachedText: CachableText = cacher.load(fileName: "text") {
+		if let cachedText: CachableText = try? cacher.load(fileName: "text") {
 			// Replace the current text with the cached one
 			textField.text = cachedText.value
 		}
@@ -26,8 +26,12 @@ class ViewController: UIViewController {
 	
 	@IBAction func didPressCache(_ sender: UIButton) {
 		let cachableText = CachableText(value: textField.text ?? "")
-		cacher.persist(item: cachableText) { url in
-			print("Text persisted in \(String(describing: url))")
+		cacher.persist(item: cachableText) { url, error in
+			if let error = error {
+				print("Text failed to persist: \(error)")
+			} else {
+				print("Text persisted in \(String(describing: url))")
+			}
 		}
 	}
 }

--- a/CacherTests/CacherTests.swift
+++ b/CacherTests/CacherTests.swift
@@ -13,7 +13,7 @@ class CacherTests: XCTestCase {
 	func testPersistCachableItemAtTemporaryFolder() {
 		let expectation = self.expectation(description: "Wrote file in folder")
 		
-		try! Cacher(destination: .temporary).persist(item: CachableText(text: "Raul Riera")) { url, _ in
+		Cacher(destination: .temporary)!.persist(item: CachableText(text: "Raul Riera")) { url, _ in
 			#if os(OSX)
 				let tempFolder = "T"
 			#else
@@ -31,7 +31,7 @@ class CacherTests: XCTestCase {
 	func testPersistCachableItemAtCustomFolder() {
 		let expectation = self.expectation(description: "Wrote file in folder")
 		
-		try! Cacher(destination: .atFolder("/test-folder")).persist(item: CachableText(text: "Raul Riera")) { url, _ in
+		Cacher(destination: .atFolder("/test-folder"))!.persist(item: CachableText(text: "Raul Riera")) { url, _ in
 			if url!.absoluteString.contains("/test-folder/testFile.txt") {
 				expectation.fulfill()
 			}

--- a/CacherTests/CacherTests.swift
+++ b/CacherTests/CacherTests.swift
@@ -13,7 +13,7 @@ class CacherTests: XCTestCase {
 	func testPersistCachableItemAtTemporaryFolder() {
 		let expectation = self.expectation(description: "Wrote file in folder")
 		
-		Cacher(destination: .temporary).persist(item: CachableText(text: "Raul Riera")) { url in
+		try! Cacher(destination: .temporary).persist(item: CachableText(text: "Raul Riera")) { url, _ in
 			#if os(OSX)
 				let tempFolder = "T"
 			#else
@@ -31,7 +31,7 @@ class CacherTests: XCTestCase {
 	func testPersistCachableItemAtCustomFolder() {
 		let expectation = self.expectation(description: "Wrote file in folder")
 		
-		Cacher(destination: .atFolder("/test-folder")).persist(item: CachableText(text: "Raul Riera")) { url in
+		try! Cacher(destination: .atFolder("/test-folder")).persist(item: CachableText(text: "Raul Riera")) { url, _ in
 			if url!.absoluteString.contains("/test-folder/testFile.txt") {
 				expectation.fulfill()
 			}


### PR DESCRIPTION
# Proposal
This PR proposes that failures are thrown instead of failing silently. It should be up to the consumers of this module of how to handle failures, instead of handling them internally.

## How this is accomplished
Instead of doing a silent `try?` on all throwables, all throwables are wrapped in a `do`-`catch` and rethrow any errors. 
Changes:
* Removes the optional return type from `load(filename:)`.
* Makes the initializer throw (in failure of creating a directory)
* The `completion` handler in `persist(item: completion:)` now has an optional `error` argument

To a user of this framework the changes will look like:
```diff
# init
- let cacher: Cacher = Cacher(destination: .temporary)
+ let cacher: Cacher = try! Cacher(destination: .temporary)

# load
- let cachedText: CachableText = cacher.load(fileName: "text")
+ let cachedText: CachableText = try? cacher.load(fileName: "text")

# persist
- cacher.persist(item: cachableText) { url in ...
+ cacher.persist(item: cachableText) { url, error in ...
```
@raulriera 